### PR TITLE
Release 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2020-03-26
+### Added
+- Allow to provide a custom way to resolve status in case of HTTP error via `error_status_extracting` parameter.
+
+### Deprecated
+- `failure_status` parameter to be used in case of HTTP error. Use `error_status_extracting` parameter instead.
+
+### Changed
+- In case of HTTP error, try to extract status from HTTP body before considering status as fail.
+
 ## [1.10.0] - 2020-03-25
 ### Added
 - Allow to use [`httpx`](https://pypi.python.org/pypi/httpx) instead of [`requests`](https://pypi.python.org/pypi/requests) to perform HTTP health check.
@@ -39,7 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Public release.
 
-[Unreleased]: https://github.com/Colin-b/healthpy/compare/v1.10.0...HEAD
+[Unreleased]: https://github.com/Colin-b/healthpy/compare/v1.11.0...HEAD
+[1.11.0]: https://github.com/Colin-b/healthpy/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/Colin-b/healthpy/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/Colin-b/healthpy/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/Colin-b/healthpy/compare/v1.7.0...v1.8.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://travis-ci.com/Colin-b/healthpy"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/healthpy.svg?branch=develop"></a>
 <a href="https://travis-ci.com/Colin-b/healthpy"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.com/Colin-b/healthpy"><img alt="Number of tests" src="https://img.shields.io/badge/tests-69 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/healthpy"><img alt="Number of tests" src="https://img.shields.io/badge/tests-128 passed-blue"></a>
 <a href="https://pypi.org/project/healthpy/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/healthpy"></a>
 </p>
 

--- a/healthpy/httpx.py
+++ b/healthpy/httpx.py
@@ -28,6 +28,7 @@ def check(
     failure_status: str = None,
     affected_endpoints: List[str] = None,
     additional_keys: dict = None,
+    error_status_extracting: callable = None,
     **httpx_args,
 ) -> (str, dict):
     """
@@ -37,19 +38,21 @@ def check(
     :param url: External service health check URL.
     :param status_extracting: Function returning status according to the JSON or text response (as parameter).
     Default to the way status should be extracted from a service following healthcheck RFC.
-    :param failure_status: Status to return in case of failure (Exception or HTTP rejection). healthpy.fail_status by default.
+    :param error_status_extracting: Function returning status according to the JSON or text response (as parameter).
+    Default to the way status should be extracted from a service following healthcheck RFC or fail_status.
     :param affected_endpoints: List of endpoints affected if dependency is down. Default to None.
     :param additional_keys: Additional user defined keys to send in checks.
     :return: A tuple with a string providing the status (amongst healthpy.*_status variable) and the "Checks object".
     Based on https://inadarei.github.io/rfc-healthcheck/
     """
     return _check(
-        service_name,
-        url,
-        _Request,
-        status_extracting,
-        failure_status,
-        affected_endpoints,
-        additional_keys,
+        service_name=service_name,
+        url=url,
+        request_class=_Request,
+        status_extracting=status_extracting,
+        failure_status=failure_status,
+        affected_endpoints=affected_endpoints,
+        additional_keys=additional_keys,
+        error_status_extracting=error_status_extracting,
         **httpx_args,
     )

--- a/healthpy/requests.py
+++ b/healthpy/requests.py
@@ -27,6 +27,7 @@ def check(
     failure_status: str = None,
     affected_endpoints: List[str] = None,
     additional_keys: dict = None,
+    error_status_extracting: callable = None,
     **requests_args,
 ) -> (str, dict):
     """
@@ -36,19 +37,21 @@ def check(
     :param url: External service health check URL.
     :param status_extracting: Function returning status according to the JSON or text response (as parameter).
     Default to the way status should be extracted from a service following healthcheck RFC.
-    :param failure_status: Status to return in case of failure (Exception or HTTP rejection). healthpy.fail_status by default.
+    :param error_status_extracting: Function returning status according to the JSON or text response (as parameter).
+    Default to the way status should be extracted from a service following healthcheck RFC or fail_status.
     :param affected_endpoints: List of endpoints affected if dependency is down. Default to None.
     :param additional_keys: Additional user defined keys to send in checks.
     :return: A tuple with a string providing the status (amongst healthpy.*_status variable) and the "Checks object".
     Based on https://inadarei.github.io/rfc-healthcheck/
     """
     return _check(
-        service_name,
-        url,
-        _Request,
-        status_extracting,
-        failure_status,
-        affected_endpoints,
-        additional_keys,
+        service_name=service_name,
+        url=url,
+        request_class=_Request,
+        status_extracting=status_extracting,
+        failure_status=failure_status,
+        affected_endpoints=affected_endpoints,
+        additional_keys=additional_keys,
+        error_status_extracting=error_status_extracting,
         **requests_args,
     )

--- a/healthpy/version.py
+++ b/healthpy/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "1.10.0"
+__version__ = "1.11.0"

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -364,6 +364,93 @@ def test_warn_status_health_check(mock_http_health_datetime, responses: Requests
     )
 
 
+def test_warn_status_http_error_health_check(
+    mock_http_health_datetime, responses: RequestsMock
+):
+    responses.add(
+        url="http://test/health",
+        method=responses.GET,
+        status=429,
+        json={
+            "status": "warn",
+            "version": "1",
+            "releaseId": "1.2.3",
+            "details": {"toto": "tata"},
+        },
+    )
+    assert healthpy.http.check("tests", "http://test/health") == (
+        "warn",
+        {
+            "tests:health": {
+                "componentType": "http://test/health",
+                "output": {
+                    "status": "warn",
+                    "version": "1",
+                    "releaseId": "1.2.3",
+                    "details": {"toto": "tata"},
+                },
+                "status": "warn",
+                "time": "2018-10-11T15:05:05.663979",
+            }
+        },
+    )
+
+
+def test_custom_http_error_status_health_check(
+    mock_http_health_datetime, responses: RequestsMock
+):
+    responses.add(
+        url="http://test/health", method=responses.GET, status=500,
+    )
+    assert healthpy.http.check(
+        "tests",
+        "http://test/health",
+        error_status_extracting=lambda x: healthpy.warn_status,
+    ) == (
+        "warn",
+        {
+            "tests:health": {
+                "componentType": "http://test/health",
+                "output": "",
+                "status": "warn",
+                "time": "2018-10-11T15:05:05.663979",
+            }
+        },
+    )
+
+
+def test_fail_status_http_error_health_check(
+    mock_http_health_datetime, responses: RequestsMock
+):
+    responses.add(
+        url="http://test/health",
+        method=responses.GET,
+        status=400,
+        json={
+            "status": "fail",
+            "version": "1",
+            "releaseId": "1.2.3",
+            "details": {"toto": "tata"},
+        },
+    )
+    assert healthpy.http.check("tests", "http://test/health") == (
+        "fail",
+        {
+            "tests:health": {
+                "componentType": "http://test/health",
+                "output": {
+                    "status": "fail",
+                    "version": "1",
+                    "releaseId": "1.2.3",
+                    "details": {"toto": "tata"},
+                },
+                "status": "fail",
+                "time": "2018-10-11T15:05:05.663979",
+            }
+        },
+    )
+
+
 def test_warn_status_health_check_additional_keys(
     mock_http_health_datetime, responses: RequestsMock
 ):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -338,6 +338,93 @@ def test_pass_status_custom_health_check_with_default_extractor_and_custom_pass_
     )
 
 
+def test_warn_status_http_error_health_check(
+    mock_http_health_datetime, responses: RequestsMock
+):
+    responses.add(
+        url="http://test/health",
+        method=responses.GET,
+        status=429,
+        json={
+            "status": "warn",
+            "version": "1",
+            "releaseId": "1.2.3",
+            "details": {"toto": "tata"},
+        },
+    )
+    assert healthpy.requests.check("tests", "http://test/health") == (
+        "warn",
+        {
+            "tests:health": {
+                "componentType": "http://test/health",
+                "output": {
+                    "status": "warn",
+                    "version": "1",
+                    "releaseId": "1.2.3",
+                    "details": {"toto": "tata"},
+                },
+                "status": "warn",
+                "time": "2018-10-11T15:05:05.663979",
+            }
+        },
+    )
+
+
+def test_custom_http_error_status_health_check(
+    mock_http_health_datetime, responses: RequestsMock
+):
+    responses.add(
+        url="http://test/health", method=responses.GET, status=500,
+    )
+    assert healthpy.requests.check(
+        "tests",
+        "http://test/health",
+        error_status_extracting=lambda x: healthpy.warn_status,
+    ) == (
+        "warn",
+        {
+            "tests:health": {
+                "componentType": "http://test/health",
+                "output": "",
+                "status": "warn",
+                "time": "2018-10-11T15:05:05.663979",
+            }
+        },
+    )
+
+
+def test_fail_status_http_error_health_check(
+    mock_http_health_datetime, responses: RequestsMock
+):
+    responses.add(
+        url="http://test/health",
+        method=responses.GET,
+        status=400,
+        json={
+            "status": "fail",
+            "version": "1",
+            "releaseId": "1.2.3",
+            "details": {"toto": "tata"},
+        },
+    )
+    assert healthpy.requests.check("tests", "http://test/health") == (
+        "fail",
+        {
+            "tests:health": {
+                "componentType": "http://test/health",
+                "output": {
+                    "status": "fail",
+                    "version": "1",
+                    "releaseId": "1.2.3",
+                    "details": {"toto": "tata"},
+                },
+                "status": "fail",
+                "time": "2018-10-11T15:05:05.663979",
+            }
+        },
+    )
+
+
 def test_warn_status_health_check(mock_http_health_datetime, responses: RequestsMock):
     responses.add(
         url="http://test/health",


### PR DESCRIPTION
### Added
- Allow to provide a custom way to resolve status in case of HTTP error via `error_status_extracting` parameter.

### Deprecated
- `failure_status` parameter to be used in case of HTTP error. Use `error_status_extracting` parameter instead.

### Changed
- In case of HTTP error, try to extract status from HTTP body before considering status as fail.
