### PR TITLE
Release 1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.1] - 2020-07-27
+### Fixed
+- error_status_extracting is now used to extract the status to return in case of failure as well. (default to failure_status)
+
+### Changed
+- The parameter provided to error_status_extracting will be `None` in case of a failure.
+
 ## [1.11.0] - 2020-03-26
 ### Added
 - Allow to provide a custom way to resolve status in case of HTTP error via `error_status_extracting` parameter.
@@ -49,7 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Public release.
 
-[Unreleased]: https://github.com/Colin-b/healthpy/compare/v1.11.0...HEAD
+[Unreleased]: https://github.com/Colin-b/healthpy/compare/v1.11.1...HEAD
+[1.11.1]: https://github.com/Colin-b/healthpy/compare/v1.11.0...v1.11.1
 [1.11.0]: https://github.com/Colin-b/healthpy/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/Colin-b/healthpy/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/Colin-b/healthpy/compare/v1.8.0...v1.9.0

--- a/healthpy/httpx.py
+++ b/healthpy/httpx.py
@@ -40,6 +40,7 @@ def check(
     Default to the way status should be extracted from a service following healthcheck RFC.
     :param error_status_extracting: Function returning status according to the JSON or text response (as parameter).
     Default to the way status should be extracted from a service following healthcheck RFC or fail_status.
+    Note that the response might be None as this is called to extract the default status in case of failure as well.
     :param affected_endpoints: List of endpoints affected if dependency is down. Default to None.
     :param additional_keys: Additional user defined keys to send in checks.
     :return: A tuple with a string providing the status (amongst healthpy.*_status variable) and the "Checks object".

--- a/healthpy/requests.py
+++ b/healthpy/requests.py
@@ -39,6 +39,7 @@ def check(
     Default to the way status should be extracted from a service following healthcheck RFC.
     :param error_status_extracting: Function returning status according to the JSON or text response (as parameter).
     Default to the way status should be extracted from a service following healthcheck RFC or fail_status.
+    Note that the response might be None as this is called to extract the default status in case of failure as well.
     :param affected_endpoints: List of endpoints affected if dependency is down. Default to None.
     :param additional_keys: Additional user defined keys to send in checks.
     :return: A tuple with a string providing the status (amongst healthpy.*_status variable) and the "Checks object".

--- a/healthpy/version.py
+++ b/healthpy/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "1.11.0"
+__version__ = "1.11.1"


### PR DESCRIPTION
### Fixed
- error_status_extracting is now used to extract the status to return in case of failure as well. (default to failure_status)

### Changed
- The parameter provided to error_status_extracting will be `None` in case of a failure.
