### PR TITLE
Release 1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.6"
   - "3.7"
   - "3.8"
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2020-09-21
+### Added
+- `healthpy.flask_restx.add_consul_health_endpoint` function to add a [Consul](https://www.consul.io/docs/agent/checks.html) health check endpoint to a [Flask-RestX](https://flask-restx.readthedocs.io/en/latest/) application.
+
 ## [1.11.1] - 2020-07-27
 ### Fixed
 - error_status_extracting is now used to extract the status to return in case of failure as well. (default to failure_status)
@@ -56,7 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Public release.
 
-[Unreleased]: https://github.com/Colin-b/healthpy/compare/v1.11.1...HEAD
+[Unreleased]: https://github.com/Colin-b/healthpy/compare/v1.12.0...HEAD
+[1.12.0]: https://github.com/Colin-b/healthpy/compare/v1.11.1...v1.12.0
 [1.11.1]: https://github.com/Colin-b/healthpy/compare/v1.11.0...v1.11.1
 [1.11.0]: https://github.com/Colin-b/healthpy/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/Colin-b/healthpy/compare/v1.9.0...v1.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `healthpy.flask_restx.add_consul_health_endpoint` function to add a [Consul](https://www.consul.io/docs/agent/checks.html) health check endpoint to a [Flask-RestX](https://flask-restx.readthedocs.io/en/latest/) application.
 
+### Changed
+- From now on, Python 3.7 is the minimum supported version (no more support for Python 3.6)
+
 ## [1.11.1] - 2020-07-27
 ### Fixed
 - error_status_extracting is now used to extract the status to return in case of failure as well. (default to failure_status)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 <p align="center">
 <a href="https://pypi.org/project/healthpy/"><img alt="pypi version" src="https://img.shields.io/pypi/v/healthpy"></a>
-<a href="https://travis-ci.com/Colin-b/healthpy"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/healthpy.svg?branch=develop"></a>
+<a href="https://travis-ci.com/Colin-b/healthpy"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/healthpy.svg?branch=master"></a>
 <a href="https://travis-ci.com/Colin-b/healthpy"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.com/Colin-b/healthpy"><img alt="Number of tests" src="https://img.shields.io/badge/tests-128 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/healthpy"><img alt="Number of tests" src="https://img.shields.io/badge/tests-136 passed-blue"></a>
 <a href="https://pypi.org/project/healthpy/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/healthpy"></a>
 </p>
 
@@ -21,6 +21,7 @@ Create an health check endpoint on your REST API following [Health Check RFC](ht
   - [HTTP response status code](#http-response-status-code)
 - [Endpoint](#endpoint)
   - [Starlette](#starlette)
+  - [Flask-RestX](#flask-restx)
 
 ## Perform checks
 
@@ -146,7 +147,7 @@ An helper function is available to create a [starlette](https://www.starlette.io
 ```python
 from starlette.applications import Starlette
 import healthpy
-import healthpy.http
+import healthpy.httpx
 import healthpy.redis
 from healthpy.starlette import add_consul_health_endpoint
 
@@ -156,7 +157,7 @@ app = Starlette()
 
 async def health_check():
     # TODO Replace by your own checks.
-    status_1, checks_1 = healthpy.http.check("my external dependency", "http://url_to_check")
+    status_1, checks_1 = healthpy.httpx.check("my external dependency", "http://url_to_check")
     status_2, checks_2 = healthpy.redis.check("redis://redis_url", "key_to_check")
     return healthpy.status(status_1, status_2), {**checks_1, **checks_2}
 
@@ -165,6 +166,35 @@ add_consul_health_endpoint(app, health_check)
 ```
 
 Note: [starlette](https://pypi.python.org/pypi/starlette) module must be installed.
+
+### Flask-RestX
+
+An helper function is available to create a [Flask-RestX](https://flask-restx.readthedocs.io/en/latest/) endpoint for [Consul](https://www.consul.io/docs/agent/checks.html) health check.
+
+```python
+import flask
+import flask_restx
+import healthpy
+import healthpy.httpx
+import healthpy.redis
+from healthpy.flask_restx import add_consul_health_endpoint
+
+
+app = flask.Flask(__name__)
+api = flask_restx.Api(app)
+
+
+async def health_check():
+    # TODO Replace by your own checks.
+    status_1, checks_1 = healthpy.httpx.check("my external dependency", "http://url_to_check")
+    status_2, checks_2 = healthpy.redis.check("redis://redis_url", "key_to_check")
+    return healthpy.status(status_1, status_2), {**checks_1, **checks_2}
+
+# /health endpoint will call the health_check coroutine.
+add_consul_health_endpoint(api, health_check)
+```
+
+Note: [flask-restx](https://pypi.python.org/pypi/flask-restx) module must be installed.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ def test_http(mock_http_health_datetime):
 ```
 
 ## How to install
-1. [python 3.6+](https://www.python.org/downloads/) must be installed
+1. [python 3.7+](https://www.python.org/downloads/) must be installed
 2. Use pip to install module:
 ```sh
 python -m pip install healthpy

--- a/healthpy/flask_restx.py
+++ b/healthpy/flask_restx.py
@@ -1,0 +1,151 @@
+import json
+from typing import Callable, Union
+import asyncio
+
+import flask_restx
+import flask
+
+import healthpy
+from healthpy._response import response_body, consul_response_status_code
+
+
+def add_consul_health_endpoint(
+    namespace: Union[flask_restx.Namespace, flask_restx.Api],
+    health_check: Callable,
+    **kwargs
+):
+    """
+    Create /health: Consul Health check endpoint implementing https://inadarei.github.io/rfc-healthcheck/ but following
+    Consul expected status code (https://www.consul.io/docs/agent/checks.html).
+
+    :param namespace: The Flask-RestX namespace.
+    :param health_check: async callable returning a tuple of size 2 with a string providing the status (pass, warn, fail)
+    and the "Checks object" as a dictionary as per https://inadarei.github.io/rfc-healthcheck/
+    :param version: (optional) public version of the service. If not provided, version will be extracted from the
+    release_id, considering that release_id is following semantic versioning.
+    Version will be considered as the MAJOR component of a MAJOR.MINOR.PATCH release_id.
+    :param release_id: (optional) in well-designed APIs, backwards-compatible changes in the service
+    should not update a version number. APIs usually change their version number as infrequently as possible,
+    to preserve stable interface. However, implementation of an API may change much more frequently,
+    which leads to the importance of having separate “release number” or “releaseId”
+    that is different from the public version of the API.
+    :param notes: (optional) array of notes relevant to current state of health.
+    :param links: (optional) is an object containing link relations and URIs [RFC3986]
+    for external links that MAY contain more information about the health of the endpoint.
+    All values of this object SHALL be URIs. Keys MAY also be URIs.
+    Per web-linking standards [RFC8288] a link relationship SHOULD either be a common/registered one
+    or be indicated as a URI, to avoid name clashes.
+    If a “self” link is provided, it MAY be used by clients to check health via HTTP response code, as mentioned above.
+    :param service_id: (optional) is a unique identifier of the service, in the application scope.
+    :param description: (optional) is a human-friendly description of the service.
+    """
+
+    @namespace.route("/health")
+    @namespace.doc(
+        responses={
+            200: (
+                "Server is in a coherent state.",
+                namespace.model(
+                    "HealthPass",
+                    {
+                        "status": flask_restx.fields.String(
+                            description="Indicates whether the service status is acceptable or not.",
+                            required=True,
+                            example="pass",
+                            enum=["pass"],
+                        ),
+                        "version": flask_restx.fields.String(
+                            description="Public version of the service.",
+                            required=True,
+                            example="1",
+                        ),
+                        "releaseId": flask_restx.fields.String(
+                            description="Version of the service.",
+                            required=True,
+                            example="1.0.0",
+                        ),
+                        "checks": flask_restx.fields.Raw(
+                            description="Provides more details about the status of the service.",
+                            required=True,
+                        ),
+                    },
+                ),
+            ),
+            429: (
+                "Server is almost in a coherent state.",
+                namespace.model(
+                    "HealthWarn",
+                    {
+                        "status": flask_restx.fields.String(
+                            description="Indicates whether the service status is acceptable or not.",
+                            required=True,
+                            example="warn",
+                            enum=["warn"],
+                        ),
+                        "version": flask_restx.fields.String(
+                            description="Public version of the service.",
+                            required=True,
+                            example="1",
+                        ),
+                        "releaseId": flask_restx.fields.String(
+                            description="Version of the service.",
+                            required=True,
+                            example="1.0.0",
+                        ),
+                        "checks": flask_restx.fields.Raw(
+                            description="Provides more details about the status of the service.",
+                            required=True,
+                        ),
+                    },
+                ),
+            ),
+            400: (
+                "Server is not in a coherent state.",
+                namespace.model(
+                    "HealthFail",
+                    {
+                        "status": flask_restx.fields.String(
+                            description="Indicates whether the service status is acceptable or not.",
+                            required=True,
+                            example="fail",
+                            enum=["fail"],
+                        ),
+                        "version": flask_restx.fields.String(
+                            description="Public version of the service.",
+                            required=True,
+                            example="1",
+                        ),
+                        "releaseId": flask_restx.fields.String(
+                            description="Version of the service.",
+                            required=True,
+                            example="1.0.0",
+                        ),
+                        "checks": flask_restx.fields.Raw(
+                            description="Provides more details about the status of the service.",
+                            required=True,
+                        ),
+                        "output": flask_restx.fields.String(
+                            description="Raw error output.", required=False
+                        ),
+                    },
+                ),
+            ),
+        }
+    )
+    class Health(flask_restx.Resource):
+        def get(self):
+            """
+            Check service health.
+            This endpoint perform a quick server state check.
+            """
+            try:
+                status, checks = asyncio.run(health_check())
+                body = response_body(status, checks=checks, **kwargs)
+            except Exception as e:
+                status = healthpy.fail_status
+                body = response_body(status, output=str(e), **kwargs)
+            return flask.Response(
+                json.dumps(body),
+                status=consul_response_status_code(status),
+                content_type="application/health+json",
+            )

--- a/healthpy/version.py
+++ b/healthpy/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "1.11.1"
+__version__ = "1.12.0"

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,13 @@ setup(
             # Used to mock requests HTTP responses
             "pytest-responses==0.4.*",
             # Used to mock httpx HTTP responses
-            "pytest-httpx==0.2.*",
+            "pytest-httpx==0.8.*",
             # Used to check redis health
             "redis==3.*",
             # Used to check starlette endpoint
             "starlette==0.13.*",
+            # Used to check flask-restx endpoint
+            "flask-restx==0.2.*",
             # Used to check coverage
             "pytest-cov==2.*",
         ]

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         "Natural Language :: English",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Topic :: Software Development :: Build Tools",
@@ -49,7 +48,7 @@ setup(
             "pytest-cov==2.*",
         ]
     },
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     project_urls={
         "GitHub": "https://github.com/Colin-b/healthpy",
         "Changelog": "https://github.com/Colin-b/healthpy/blob/master/CHANGELOG.md",

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -15,7 +15,7 @@ def test_exception_health_check(mock_http_health_datetime, httpx_mock: HTTPXMock
         {
             "tests:health": {
                 "componentType": "http://test/health",
-                "output": "No mock can be found for GET request on http://test/health.",
+                "output": "No response can be found for GET request on http://test/health",
                 "status": "fail",
                 "time": "2018-10-11T15:05:05.663979",
             }
@@ -33,7 +33,7 @@ def test_exception_health_check_additional_keys(
         {
             "tests:health": {
                 "componentType": "http://test/health",
-                "output": "No mock can be found for GET request on http://test/health.",
+                "output": "No response can be found for GET request on http://test/health",
                 "status": "fail",
                 "time": "2018-10-11T15:05:05.663979",
                 "custom": "test",
@@ -51,7 +51,7 @@ def test_exception_health_check_with_custom_status(
         {
             "tests:health": {
                 "componentType": "http://test/health",
-                "output": "No mock can be found for GET request on http://test/health.",
+                "output": "No response can be found for GET request on http://test/health",
                 "status": "custom failure",
                 "time": "2018-10-11T15:05:05.663979",
             }
@@ -69,7 +69,7 @@ def test_exception_health_check_as_warn(
         {
             "tests:health": {
                 "componentType": "http://test/health",
-                "output": "No mock can be found for GET request on http://test/health.",
+                "output": "No response can be found for GET request on http://test/health",
                 "status": "warn",
                 "time": "2018-10-11T15:05:05.663979",
             }
@@ -89,7 +89,7 @@ def test_exception_health_check_as_warn_even_with_custom_status(
         {
             "tests:health": {
                 "componentType": "http://test/health",
-                "output": "No mock can be found for GET request on http://test/health.",
+                "output": "No response can be found for GET request on http://test/health",
                 "status": "warn provided",
                 "time": "2018-10-11T15:05:05.663979",
             }
@@ -434,8 +434,8 @@ def test_custom_http_error_status_health_check(
 def test_custom_failure_status_health_check(
     mock_http_health_datetime, httpx_mock: HTTPXMock
 ):
-    def send_failure(*args, **kwargs):
-        raise httpx.NetworkError()
+    def send_failure(request, timeout):
+        raise httpx.NetworkError("", request=request)
 
     httpx_mock.add_callback(
         url="http://test/health", method="GET", callback=send_failure
@@ -460,8 +460,8 @@ def test_custom_failure_status_health_check(
 def test_custom_failure_status_exception_health_check(
     mock_http_health_datetime, httpx_mock: HTTPXMock
 ):
-    def send_failure(*args, **kwargs):
-        raise httpx.NetworkError()
+    def send_failure(request, timeout):
+        raise httpx.NetworkError("", request=request)
 
     httpx_mock.add_callback(
         url="http://test/health", method="GET", callback=send_failure
@@ -629,7 +629,7 @@ def test_fail_status_when_server_is_down(
         {
             "tests:health": {
                 "componentType": "http://test/status",
-                "output": "No mock can be found for GET request on http://test/status.",
+                "output": "No response can be found for GET request on http://test/status",
                 "status": "fail",
                 "time": "2018-10-11T15:05:05.663979",
             }
@@ -647,7 +647,7 @@ def test_fail_status_when_server_is_down_as_warn(
         {
             "tests:health": {
                 "componentType": "http://test/status",
-                "output": "No mock can be found for GET request on http://test/status.",
+                "output": "No response can be found for GET request on http://test/status",
                 "status": "warn",
                 "time": "2018-10-11T15:05:05.663979",
             }
@@ -668,7 +668,7 @@ def test_show_affected_endpoints_when_endpoint_throws_exception(
         {
             "tests:health": {
                 "componentType": "http://test/status",
-                "output": "No mock can be found for GET request on http://test/status.",
+                "output": "No response can be found for GET request on http://test/status",
                 "status": "warn",
                 "affectedEndpoints": ["/testroute/{userId}", "/status/{id}/idontexist"],
                 "time": "2018-10-11T15:05:05.663979",

--- a/tests/test_z_flask_restx.py
+++ b/tests/test_z_flask_restx.py
@@ -1,0 +1,76 @@
+import flask
+import flask_restx
+
+from healthpy.flask_restx import add_consul_health_endpoint
+
+
+def test_consul_health_endpoint_pass():
+    async def health_check():
+        return "pass", {}
+
+    app = flask.Flask(__name__)
+    api = flask_restx.Api(app)
+    add_consul_health_endpoint(api, health_check, release_id="1.2.3")
+    with app.test_client() as client:
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json == {
+            "checks": {},
+            "releaseId": "1.2.3",
+            "status": "pass",
+            "version": "1",
+        }
+
+
+def test_consul_health_endpoint_warn():
+    async def health_check():
+        return "warn", {}
+
+    app = flask.Flask(__name__)
+    api = flask_restx.Api(app)
+    add_consul_health_endpoint(api, health_check, release_id="1.2.3")
+    with app.test_client() as client:
+        response = client.get("/health")
+        assert response.status_code == 429
+        assert response.json == {
+            "checks": {},
+            "releaseId": "1.2.3",
+            "status": "warn",
+            "version": "1",
+        }
+
+
+def test_consul_health_endpoint_fail():
+    async def health_check():
+        return "fail", {}
+
+    app = flask.Flask(__name__)
+    api = flask_restx.Api(app)
+    add_consul_health_endpoint(api, health_check, release_id="1.2.3")
+    with app.test_client() as client:
+        response = client.get("/health")
+        assert response.status_code == 400
+        assert response.json == {
+            "checks": {},
+            "releaseId": "1.2.3",
+            "status": "fail",
+            "version": "1",
+        }
+
+
+def test_consul_health_endpoint_failure():
+    async def failing():
+        raise Exception("failure explanation")
+
+    app = flask.Flask(__name__)
+    api = flask_restx.Api(app)
+    add_consul_health_endpoint(api, failing, release_id="1.2.3")
+    with app.test_client() as client:
+        response = client.get("/health")
+        assert response.status_code == 400
+        assert response.json == {
+            "output": "failure explanation",
+            "releaseId": "1.2.3",
+            "status": "fail",
+            "version": "1",
+        }


### PR DESCRIPTION
### Added
- `healthpy.flask_restx.add_consul_health_endpoint` function to add a [Consul](https://www.consul.io/docs/agent/checks.html) health check endpoint to a [Flask-RestX](https://flask-restx.readthedocs.io/en/latest/) application.
