### PR TITLE
Release 1.13.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: master
+    rev: 20.8b1
     hooks:
       - id: black

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.7"
   - "3.8"
+  - "3.9-dev"
 install:
   - pip install .[testing]
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] - 2020-10-15
+### Added
+- `healthpy.flask_restx.add_health_endpoint` function to add a health check endpoint to a [Flask-RestX](https://flask-restx.readthedocs.io/en/latest/) application.
+- Explicit support for python `3.9`.
+
+### Changed
+- Follow `black` `20.8b1` formatting instead of the git master.
+
 ## [1.12.0] - 2020-09-21
 ### Added
 - `healthpy.flask_restx.add_consul_health_endpoint` function to add a [Consul](https://www.consul.io/docs/agent/checks.html) health check endpoint to a [Flask-RestX](https://flask-restx.readthedocs.io/en/latest/) application.
@@ -63,7 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Public release.
 
-[Unreleased]: https://github.com/Colin-b/healthpy/compare/v1.12.0...HEAD
+[Unreleased]: https://github.com/Colin-b/healthpy/compare/v1.13.0...HEAD
+[1.13.0]: https://github.com/Colin-b/healthpy/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/Colin-b/healthpy/compare/v1.11.1...v1.12.0
 [1.11.1]: https://github.com/Colin-b/healthpy/compare/v1.11.0...v1.11.1
 [1.11.0]: https://github.com/Colin-b/healthpy/compare/v1.10.0...v1.11.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://travis-ci.com/Colin-b/healthpy"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/healthpy.svg?branch=master"></a>
 <a href="https://travis-ci.com/Colin-b/healthpy"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.com/Colin-b/healthpy"><img alt="Number of tests" src="https://img.shields.io/badge/tests-136 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/healthpy"><img alt="Number of tests" src="https://img.shields.io/badge/tests-140 passed-blue"></a>
 <a href="https://pypi.org/project/healthpy/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/healthpy"></a>
 </p>
 
@@ -168,6 +168,36 @@ add_consul_health_endpoint(app, health_check)
 Note: [starlette](https://pypi.python.org/pypi/starlette) module must be installed.
 
 ### Flask-RestX
+
+An helper function is available to create a [Flask-RestX](https://flask-restx.readthedocs.io/en/latest/) endpoint for health check.
+
+```python
+import flask
+import flask_restx
+import healthpy
+import healthpy.httpx
+import healthpy.redis
+from healthpy.flask_restx import add_health_endpoint
+
+
+app = flask.Flask(__name__)
+api = flask_restx.Api(app)
+
+
+async def health_check():
+    # TODO Replace by your own checks.
+    status_1, checks_1 = healthpy.httpx.check("my external dependency", "http://url_to_check")
+    status_2, checks_2 = healthpy.redis.check("redis://redis_url", "key_to_check")
+    return healthpy.status(status_1, status_2), {**checks_1, **checks_2}
+
+# /health endpoint will call the health_check coroutine.
+add_health_endpoint(api, health_check)
+```
+
+Note: [flask-restx](https://pypi.python.org/pypi/flask-restx) module must be installed.
+
+
+#### Consul Service Health check
 
 An helper function is available to create a [Flask-RestX](https://flask-restx.readthedocs.io/en/latest/) endpoint for [Consul](https://www.consul.io/docs/agent/checks.html) health check.
 

--- a/healthpy/flask_restx.py
+++ b/healthpy/flask_restx.py
@@ -6,7 +6,11 @@ import flask_restx
 import flask
 
 import healthpy
-from healthpy._response import response_body, consul_response_status_code
+from healthpy._response import (
+    response_body,
+    consul_response_status_code,
+    response_status_code,
+)
 
 
 def add_consul_health_endpoint(
@@ -147,5 +151,118 @@ def add_consul_health_endpoint(
             return flask.Response(
                 json.dumps(body),
                 status=consul_response_status_code(status),
+                content_type="application/health+json",
+            )
+
+
+def add_health_endpoint(
+    namespace: Union[flask_restx.Namespace, flask_restx.Api],
+    health_check: Callable,
+    **kwargs
+):
+    """
+    Create /health: Health check endpoint implementing https://inadarei.github.io/rfc-healthcheck/.
+
+    :param namespace: The Flask-RestX namespace.
+    :param health_check: async callable returning a tuple of size 2 with a string providing the status (pass, warn, fail)
+    and the "Checks object" as a dictionary as per https://inadarei.github.io/rfc-healthcheck/
+    :param version: (optional) public version of the service. If not provided, version will be extracted from the
+    release_id, considering that release_id is following semantic versioning.
+    Version will be considered as the MAJOR component of a MAJOR.MINOR.PATCH release_id.
+    :param release_id: (optional) in well-designed APIs, backwards-compatible changes in the service
+    should not update a version number. APIs usually change their version number as infrequently as possible,
+    to preserve stable interface. However, implementation of an API may change much more frequently,
+    which leads to the importance of having separate “release number” or “releaseId”
+    that is different from the public version of the API.
+    :param notes: (optional) array of notes relevant to current state of health.
+    :param links: (optional) is an object containing link relations and URIs [RFC3986]
+    for external links that MAY contain more information about the health of the endpoint.
+    All values of this object SHALL be URIs. Keys MAY also be URIs.
+    Per web-linking standards [RFC8288] a link relationship SHOULD either be a common/registered one
+    or be indicated as a URI, to avoid name clashes.
+    If a “self” link is provided, it MAY be used by clients to check health via HTTP response code, as mentioned above.
+    :param service_id: (optional) is a unique identifier of the service, in the application scope.
+    :param description: (optional) is a human-friendly description of the service.
+    """
+
+    @namespace.route("/health")
+    @namespace.doc(
+        responses={
+            200: (
+                "Server is (almost) in a coherent state.",
+                namespace.model(
+                    "HealthPassOrWarn",
+                    {
+                        "status": flask_restx.fields.String(
+                            description="Indicates whether the service status is acceptable or not.",
+                            required=True,
+                            example="pass",
+                            enum=["pass"],
+                        ),
+                        "version": flask_restx.fields.String(
+                            description="Public version of the service.",
+                            required=True,
+                            example="1",
+                        ),
+                        "releaseId": flask_restx.fields.String(
+                            description="Version of the service.",
+                            required=True,
+                            example="1.0.0",
+                        ),
+                        "checks": flask_restx.fields.Raw(
+                            description="Provides more details about the status of the service.",
+                            required=True,
+                        ),
+                    },
+                ),
+            ),
+            400: (
+                "Server is not in a coherent state.",
+                namespace.model(
+                    "HealthFail",
+                    {
+                        "status": flask_restx.fields.String(
+                            description="Indicates whether the service status is acceptable or not.",
+                            required=True,
+                            example="fail",
+                            enum=["fail"],
+                        ),
+                        "version": flask_restx.fields.String(
+                            description="Public version of the service.",
+                            required=True,
+                            example="1",
+                        ),
+                        "releaseId": flask_restx.fields.String(
+                            description="Version of the service.",
+                            required=True,
+                            example="1.0.0",
+                        ),
+                        "checks": flask_restx.fields.Raw(
+                            description="Provides more details about the status of the service.",
+                            required=True,
+                        ),
+                        "output": flask_restx.fields.String(
+                            description="Raw error output.", required=False
+                        ),
+                    },
+                ),
+            ),
+        }
+    )
+    class Health(flask_restx.Resource):
+        def get(self):
+            """
+            Check service health.
+            This endpoint perform a quick server state check.
+            """
+            try:
+                status, checks = asyncio.run(health_check())
+                body = response_body(status, checks=checks, **kwargs)
+            except Exception as e:
+                status = healthpy.fail_status
+                body = response_body(status, output=str(e), **kwargs)
+            return flask.Response(
+                json.dumps(body),
+                status=response_status_code(status),
                 content_type="application/health+json",
             )

--- a/healthpy/version.py
+++ b/healthpy/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "1.12.0"
+__version__ = "1.13.0"

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Build Tools",
     ],
     keywords=["health", "api", "http", "redis"],
@@ -37,7 +38,7 @@ setup(
             # Used to mock requests HTTP responses
             "pytest-responses==0.4.*",
             # Used to mock httpx HTTP responses
-            "pytest-httpx==0.8.*",
+            "pytest-httpx==0.10.*",
             # Used to check redis health
             "redis==3.*",
             # Used to check starlette endpoint

--- a/tests/test_httpx.py
+++ b/tests/test_httpx.py
@@ -1,7 +1,5 @@
 import json
-import os
 
-import pytest
 from pytest_httpx import httpx_mock, HTTPXMock
 import httpx
 
@@ -434,7 +432,7 @@ def test_custom_http_error_status_health_check(
 def test_custom_failure_status_health_check(
     mock_http_health_datetime, httpx_mock: HTTPXMock
 ):
-    def send_failure(request, timeout):
+    def send_failure(request, *args, **kwargs):
         raise httpx.NetworkError("", request=request)
 
     httpx_mock.add_callback(
@@ -460,7 +458,7 @@ def test_custom_failure_status_health_check(
 def test_custom_failure_status_exception_health_check(
     mock_http_health_datetime, httpx_mock: HTTPXMock
 ):
-    def send_failure(request, timeout):
+    def send_failure(request, *args, **kwargs):
         raise httpx.NetworkError("", request=request)
 
     httpx_mock.add_callback(

--- a/tests/test_z_flask_restx.py
+++ b/tests/test_z_flask_restx.py
@@ -1,7 +1,79 @@
 import flask
 import flask_restx
 
-from healthpy.flask_restx import add_consul_health_endpoint
+from healthpy.flask_restx import add_consul_health_endpoint, add_health_endpoint
+
+
+def test_health_endpoint_pass():
+    async def health_check():
+        return "pass", {}
+
+    app = flask.Flask(__name__)
+    api = flask_restx.Api(app)
+    add_health_endpoint(api, health_check, release_id="1.2.3")
+    with app.test_client() as client:
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json == {
+            "checks": {},
+            "releaseId": "1.2.3",
+            "status": "pass",
+            "version": "1",
+        }
+
+
+def test_health_endpoint_warn():
+    async def health_check():
+        return "warn", {}
+
+    app = flask.Flask(__name__)
+    api = flask_restx.Api(app)
+    add_health_endpoint(api, health_check, release_id="1.2.3")
+    with app.test_client() as client:
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json == {
+            "checks": {},
+            "releaseId": "1.2.3",
+            "status": "warn",
+            "version": "1",
+        }
+
+
+def test_health_endpoint_fail():
+    async def health_check():
+        return "fail", {}
+
+    app = flask.Flask(__name__)
+    api = flask_restx.Api(app)
+    add_health_endpoint(api, health_check, release_id="1.2.3")
+    with app.test_client() as client:
+        response = client.get("/health")
+        assert response.status_code == 400
+        assert response.json == {
+            "checks": {},
+            "releaseId": "1.2.3",
+            "status": "fail",
+            "version": "1",
+        }
+
+
+def test_health_endpoint_failure():
+    async def failing():
+        raise Exception("failure explanation")
+
+    app = flask.Flask(__name__)
+    api = flask_restx.Api(app)
+    add_health_endpoint(api, failing, release_id="1.2.3")
+    with app.test_client() as client:
+        response = client.get("/health")
+        assert response.status_code == 400
+        assert response.json == {
+            "output": "failure explanation",
+            "releaseId": "1.2.3",
+            "status": "fail",
+            "version": "1",
+        }
 
 
 def test_consul_health_endpoint_pass():


### PR DESCRIPTION
### Added
- `healthpy.flask_restx.add_health_endpoint` function to add a health check endpoint to a [Flask-RestX](https://flask-restx.readthedocs.io/en/latest/) application.
- Explicit support for python `3.9`.

### Changed
- Follow `black` `20.8b1` formatting instead of the git master.
