### PR TITLE
Release 1.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "3.7"
   - "3.8"
-  - "3.9-dev"
+  - "3.9"
 install:
   - pip install .[testing]
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2020-11-04
+### Changed
+- Forward `healthpy.httpx.check` extra parameters to the `httpx.Client` instead of the `httpx.Client.request` method. Allowing to use all `httpx` parameters.
+
 ## [1.13.0] - 2020-10-15
 ### Added
 - `healthpy.flask_restx.add_health_endpoint` function to add a health check endpoint to a [Flask-RestX](https://flask-restx.readthedocs.io/en/latest/) application.
@@ -71,7 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Public release.
 
-[Unreleased]: https://github.com/Colin-b/healthpy/compare/v1.13.0...HEAD
+[Unreleased]: https://github.com/Colin-b/healthpy/compare/v1.14.0...HEAD
+[1.14.0]: https://github.com/Colin-b/healthpy/compare/v1.13.0...v1.14.0
 [1.13.0]: https://github.com/Colin-b/healthpy/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/Colin-b/healthpy/compare/v1.11.1...v1.12.0
 [1.11.1]: https://github.com/Colin-b/healthpy/compare/v1.11.0...v1.11.1

--- a/healthpy/httpx.py
+++ b/healthpy/httpx.py
@@ -7,8 +7,8 @@ from healthpy._http import _check, _is_json
 
 class _Request:
     def __init__(self, url: str, **args):
-        with httpx.Client(timeout=args.pop("timeout", (1, 5))) as client:
-            self.response = client.get(url, **args)
+        with httpx.Client(timeout=args.pop("timeout", (1, 5)), **args) as client:
+            self.response = client.get(url)
 
     def is_error(self) -> bool:
         return self.response.is_error
@@ -43,6 +43,7 @@ def check(
     Note that the response might be None as this is called to extract the default status in case of failure as well.
     :param affected_endpoints: List of endpoints affected if dependency is down. Default to None.
     :param additional_keys: Additional user defined keys to send in checks.
+    :param httpx_args: All other parameters will be provided to the httpx.Client instance.
     :return: A tuple with a string providing the status (amongst healthpy.*_status variable) and the "Checks object".
     Based on https://inadarei.github.io/rfc-healthcheck/
     """

--- a/healthpy/httpx.py
+++ b/healthpy/httpx.py
@@ -7,8 +7,8 @@ from healthpy._http import _check, _is_json
 
 class _Request:
     def __init__(self, url: str, **args):
-        with httpx.Client() as client:
-            self.response = client.get(url, timeout=args.pop("timeout", (1, 5)), **args)
+        with httpx.Client(timeout=args.pop("timeout", (1, 5))) as client:
+            self.response = client.get(url, **args)
 
     def is_error(self) -> bool:
         return self.response.is_error

--- a/healthpy/requests.py
+++ b/healthpy/requests.py
@@ -7,7 +7,10 @@ from healthpy._http import _check, _is_json
 
 class _Request:
     def __init__(self, url: str, **args):
-        self.response = requests.get(url, timeout=args.pop("timeout", (1, 5)), **args)
+        with requests.Session() as session:
+            self.response = session.get(
+                url, timeout=args.pop("timeout", (1, 5)), **args
+            )
 
     def is_error(self) -> bool:
         return not self.response.ok

--- a/healthpy/version.py
+++ b/healthpy/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "1.13.0"
+__version__ = "1.14.0"


### PR DESCRIPTION
### Changed
- Forward `healthpy.httpx.check` extra parameters to the `httpx.Client` instead of the `httpx.Client.request` method. Allowing to use all `httpx` parameters.
